### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Read every n-th frame and save to images project",
-  "docker_image": "supervisely/data-operations:6.73.486",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.15.35",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   ],
   "description": "Read every n-th frame and save to images project",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.15.35",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Read every n-th frame and save to images project",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.486
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-import supervisely_lib as sly
+import supervisely as sly
 import workflow as w
 import cv2
 from supervisely import handle_exceptions


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
